### PR TITLE
feat: apple code signing, notarization, and auto-update

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,0 +1,18 @@
+module.exports = {
+  root: true,
+  env: { browser: true, es2020: true },
+  extends: [
+    'eslint:recommended',
+    'plugin:@typescript-eslint/recommended',
+    'plugin:react-hooks/recommended',
+  ],
+  ignorePatterns: ['dist', '.eslintrc.cjs'],
+  parser: '@typescript-eslint/parser',
+  plugins: ['react-refresh'],
+  rules: {
+    'react-refresh/only-export-components': [
+      'warn',
+      { allowConstantExport: true },
+    ],
+  },
+}

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -49,10 +49,10 @@ jobs:
         include:
           - runner: macos-latest
             target: aarch64-apple-darwin
-            tauri-args: --target aarch64-apple-darwin
+            tauri-args: --target aarch64-apple-darwin --bundles app,dmg
           - runner: windows-latest
             target: ''
-            tauri-args: ''
+            tauri-args: --bundles msi,nsis
     runs-on: ${{ matrix.runner }}
 
     steps:

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -49,10 +49,10 @@ jobs:
         include:
           - runner: macos-latest
             target: aarch64-apple-darwin
-            tauri-args: --target aarch64-apple-darwin --bundles app,dmg
+            tauri-args: --target aarch64-apple-darwin
           - runner: windows-latest
             target: ''
-            tauri-args: --bundles msi,nsis
+            tauri-args: ''
     runs-on: ${{ matrix.runner }}
 
     steps:
@@ -79,7 +79,8 @@ jobs:
         run: npm ci
 
       - name: Build Tauri app (debug)
-        run: npm run tauri build -- --debug ${{ matrix.tauri-args }}
+        shell: bash
+        run: npm run tauri build -- --debug ${{ matrix.tauri-args }} --config '{"bundle":{"createUpdaterArtifacts":false}}'
         env:
           # Ad-hoc sign on macOS so PRs don't need the signing cert
           APPLE_SIGNING_IDENTITY: '-'

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -41,3 +41,45 @@ jobs:
           name: build-output
           path: dist/
           retention-days: 7
+
+  tauri-build:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: macos-latest
+            target: aarch64-apple-darwin
+            tauri-args: --target aarch64-apple-darwin
+          - runner: windows-latest
+            target: ''
+            tauri-args: ''
+    runs-on: ${{ matrix.runner }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20.x'
+          cache: 'npm'
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - name: Cache Rust build
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: src-tauri -> target
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build Tauri app (debug)
+        run: npm run tauri build -- --debug ${{ matrix.tauri-args }}
+        env:
+          # Ad-hoc sign on macOS so PRs don't need the signing cert
+          APPLE_SIGNING_IDENTITY: '-'

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -158,7 +158,7 @@ jobs:
         uses: softprops/action-gh-release@v1
         with:
           tag_name: v${{ needs.create-release.outputs.version }}
-          files: src-tauri/target/aarch64-apple-darwin/release/bundle/macos/*.dmg
+          files: src-tauri/target/aarch64-apple-darwin/release/bundle/dmg/*.dmg
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -104,28 +104,78 @@ jobs:
         with:
           targets: ${{ matrix.target }}
 
+      - name: Import Apple Developer Certificate
+        env:
+          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
+        run: |
+          # Create a temporary keychain
+          KEYCHAIN_PATH=$RUNNER_TEMP/app-signing.keychain-db
+          security create-keychain -p "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
+          security set-keychain-settings -lut 21600 $KEYCHAIN_PATH
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
+
+          # Import certificate to keychain
+          CERTIFICATE_PATH=$RUNNER_TEMP/certificate.p12
+          echo -n "$APPLE_CERTIFICATE" | base64 --decode -o $CERTIFICATE_PATH
+          security import $CERTIFICATE_PATH -P "$APPLE_CERTIFICATE_PASSWORD" -A -t cert -f pkcs12 -k $KEYCHAIN_PATH
+          security set-key-partition-list -S apple-tool:,apple: -k "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
+          security list-keychain -d user -s $KEYCHAIN_PATH
+
       - name: Install dependencies
         run: npm ci
 
-      - name: Build Tauri app
+      - name: Build and sign Tauri app
         id: build
         run: npm run tauri build -- --target ${{ matrix.target }}
-        continue-on-error: true
         env:
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+          APPLE_SIGNING_IDENTITY: "Developer ID Application: AndrewMorgan Ltd. (NYG9V7955H)"
 
-      - name: Verify app was built
+      - name: Notarize macOS app
+        env:
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_TEAM_ID: NYG9V7955H
+          APPLE_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
         run: |
-          if [ ! -d "src-tauri/target/${{ matrix.target }}/release/bundle/macos/Markdown Editor.app" ]; then
-            echo "Error: App bundle was not created"
-            exit 1
+          DMG_PATH=$(find src-tauri/target/${{ matrix.target }}/release/bundle -name "*.dmg" -type f | head -1)
+          if [ -n "$DMG_PATH" ]; then
+            echo "Notarizing $DMG_PATH..."
+            xcrun notarytool submit "$DMG_PATH" \
+              --apple-id "$APPLE_ID" \
+              --team-id "$APPLE_TEAM_ID" \
+              --password "$APPLE_PASSWORD" \
+              --wait
+            xcrun stapler staple "$DMG_PATH"
+            echo "Notarization and stapling complete"
+          else
+            echo "No DMG found, attempting to notarize .app bundle..."
+            APP_PATH="src-tauri/target/${{ matrix.target }}/release/bundle/macos/Markdown Editor.app"
+            if [ -d "$APP_PATH" ]; then
+              # Create a zip for notarization
+              ditto -c -k --keepParent "$APP_PATH" "$RUNNER_TEMP/app.zip"
+              xcrun notarytool submit "$RUNNER_TEMP/app.zip" \
+                --apple-id "$APPLE_ID" \
+                --team-id "$APPLE_TEAM_ID" \
+                --password "$APPLE_PASSWORD" \
+                --wait
+              xcrun stapler staple "$APP_PATH"
+            fi
           fi
+
+      - name: Verify code signature
+        run: |
+          APP_PATH="src-tauri/target/${{ matrix.target }}/release/bundle/macos/Markdown Editor.app"
+          echo "=== Verifying code signature ==="
+          codesign --verify --deep --strict --verbose=2 "$APP_PATH" || echo "Warning: Code signature verification failed"
+          echo "=== Checking Gatekeeper assessment ==="
+          spctl --assess --type exec --verbose "$APP_PATH" || echo "Warning: Gatekeeper assessment failed"
 
       - name: Create DMG (fallback if Tauri bundler failed)
         run: |
           cd src-tauri/target/${{ matrix.target }}/release/bundle/macos
-          # Check if DMG already exists
           if ls Markdown\ Editor_*.dmg 1> /dev/null 2>&1; then
             echo "DMG already exists, skipping manual creation"
           else
@@ -152,6 +202,11 @@ jobs:
           files: src-tauri/target/${{ matrix.target }}/release/bundle/macos/*.dmg
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Cleanup keychain
+        if: always()
+        run: |
+          security delete-keychain $RUNNER_TEMP/app-signing.keychain-db || true
 
   build-windows:
     needs: create-release

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -62,10 +62,11 @@ jobs:
             - **PDF Export** - Export your documents to PDF
             - **Dark/Light Theme** - Switch between themes to match your preference
             - **Keyboard Shortcuts** - Cmd/Ctrl+S (save), Cmd/Ctrl+O (open), Cmd/Ctrl+N (new)
+            - **Auto Update** - Automatically checks for and installs updates
 
             ### Downloads
             - **macOS (Apple Silicon)**: `Markdown Editor_x.x.x_aarch64.dmg`
-  
+
             ### Installation
             **macOS**: Download the DMG, open it, and drag the app to Applications.
         env:
@@ -76,6 +77,8 @@ jobs:
     runs-on: macos-latest
     permissions:
       contents: write
+    outputs:
+      dmg_sig: ${{ steps.read-sig.outputs.dmg_sig }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -132,33 +135,31 @@ jobs:
           echo "=== Checking Gatekeeper assessment ==="
           spctl --assess --type exec --verbose "$APP_PATH" || echo "Warning: Gatekeeper assessment failed"
 
-      - name: Create DMG (fallback if Tauri bundler failed)
+      - name: Read update signature
+        id: read-sig
         run: |
-          cd src-tauri/target/aarch64-apple-darwin/release/bundle/macos
-          if ls Markdown\ Editor_*.dmg 1> /dev/null 2>&1; then
-            echo "DMG already exists, skipping manual creation"
+          SIG_FILE=$(find src-tauri/target/aarch64-apple-darwin/release/bundle -name "*.dmg.sig" -type f | head -1)
+          if [ -n "$SIG_FILE" ]; then
+            SIG=$(cat "$SIG_FILE")
+            echo "dmg_sig=$SIG" >> $GITHUB_OUTPUT
+            echo "Found signature: $SIG_FILE"
           else
-            echo "Creating DMG manually..."
-            TEMP_DMG_DIR=$(mktemp -d)
-            cp -R "Markdown Editor.app" "$TEMP_DMG_DIR/"
-            ln -s /Applications "$TEMP_DMG_DIR/Applications"
-            VERSION=$(node -p "require('../../../../../../package.json').version")
-            hdiutil create -volname "Markdown Editor" -srcfolder "$TEMP_DMG_DIR" -ov -format UDZO "Markdown Editor_${VERSION}_aarch64.dmg"
-            rm -rf "$TEMP_DMG_DIR"
+            echo "No .dmg.sig file found"
+            find src-tauri/target/aarch64-apple-darwin/release/bundle -name "*.sig" -type f
           fi
 
       - name: List built artifacts
         run: |
-          echo "=== Listing bundle directory ==="
-          ls -la src-tauri/target/aarch64-apple-darwin/release/bundle/macos/ || echo "Directory not found"
-          echo "=== Finding all DMG files ==="
-          find src-tauri -name "*.dmg" -type f 2>/dev/null || echo "No DMG files found"
+          echo "=== Finding all DMG and sig files ==="
+          find src-tauri/target/aarch64-apple-darwin/release/bundle -name "*.dmg" -o -name "*.sig" | sort
 
       - name: Upload DMG to Release
         uses: softprops/action-gh-release@v1
         with:
           tag_name: v${{ needs.create-release.outputs.version }}
-          files: src-tauri/target/aarch64-apple-darwin/release/bundle/dmg/*.dmg
+          files: |
+            src-tauri/target/aarch64-apple-darwin/release/bundle/dmg/*.dmg
+            src-tauri/target/aarch64-apple-darwin/release/bundle/dmg/*.sig
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -172,6 +173,9 @@ jobs:
     runs-on: windows-latest
     permissions:
       contents: write
+    outputs:
+      msi_sig: ${{ steps.read-sig.outputs.msi_sig }}
+      nsis_sig: ${{ steps.read-sig.outputs.nsis_sig }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -194,13 +198,20 @@ jobs:
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
 
+      - name: Read update signatures
+        id: read-sig
+        shell: bash
+        run: |
+          MSI_SIG=$(find src-tauri/target/release/bundle/msi -name "*.msi.sig" -type f -exec cat {} \; 2>/dev/null | head -1)
+          NSIS_SIG=$(find src-tauri/target/release/bundle/nsis -name "*.exe.sig" -type f -exec cat {} \; 2>/dev/null | head -1)
+          echo "msi_sig=$MSI_SIG" >> $GITHUB_OUTPUT
+          echo "nsis_sig=$NSIS_SIG" >> $GITHUB_OUTPUT
+
       - name: List built artifacts
         shell: pwsh
         run: |
           Write-Host "=== Listing bundle directory ==="
           Get-ChildItem -Path src-tauri/target/release/bundle -Recurse -ErrorAction SilentlyContinue | ForEach-Object { $_.FullName }
-          Write-Host "=== Finding installer files ==="
-          Get-ChildItem -Path src-tauri -Recurse -Include *.msi,*.exe -ErrorAction SilentlyContinue | ForEach-Object { $_.FullName }
 
       - name: Upload Windows installer to Release
         uses: softprops/action-gh-release@v1
@@ -208,7 +219,9 @@ jobs:
           tag_name: v${{ needs.create-release.outputs.version }}
           files: |
             src-tauri/target/release/bundle/msi/*.msi
+            src-tauri/target/release/bundle/msi/*.sig
             src-tauri/target/release/bundle/nsis/*.exe
+            src-tauri/target/release/bundle/nsis/*.sig
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -218,6 +231,41 @@ jobs:
     permissions:
       contents: write
     steps:
+      - name: Generate latest.json for updater
+        run: |
+          VERSION="${{ needs.create-release.outputs.version }}"
+          REPO="andyjmorgan/DonkeyWork-MarkdownEditor"
+          BASE_URL="https://github.com/${REPO}/releases/download/v${VERSION}"
+          DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+          cat > latest.json << EOF
+          {
+            "version": "${VERSION}",
+            "notes": "Markdown Editor v${VERSION}",
+            "pub_date": "${DATE}",
+            "platforms": {
+              "darwin-aarch64": {
+                "signature": "${{ needs.build-macos.outputs.dmg_sig }}",
+                "url": "${BASE_URL}/Markdown.Editor_${VERSION}_aarch64.dmg"
+              },
+              "windows-x86_64": {
+                "signature": "${{ needs.build-windows.outputs.nsis_sig }}",
+                "url": "${BASE_URL}/Markdown.Editor_${VERSION}_x64-setup.exe"
+              }
+            }
+          }
+          EOF
+          echo "=== latest.json ==="
+          cat latest.json
+
+      - name: Upload latest.json to Release
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: v${{ needs.create-release.outputs.version }}
+          files: latest.json
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Publish Release
         uses: softprops/action-gh-release@v1
         with:

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -78,7 +78,7 @@ jobs:
     permissions:
       contents: write
     outputs:
-      dmg_sig: ${{ steps.read-sig.outputs.dmg_sig }}
+      app_sig: ${{ steps.read-sig.outputs.app_sig }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -138,28 +138,29 @@ jobs:
       - name: Read update signature
         id: read-sig
         run: |
-          SIG_FILE=$(find src-tauri/target/aarch64-apple-darwin/release/bundle -name "*.dmg.sig" -type f | head -1)
+          SIG_FILE=$(find src-tauri/target/aarch64-apple-darwin/release/bundle -name "*.app.tar.gz.sig" -type f | head -1)
           if [ -n "$SIG_FILE" ]; then
             SIG=$(cat "$SIG_FILE")
-            echo "dmg_sig=$SIG" >> $GITHUB_OUTPUT
+            echo "app_sig=$SIG" >> $GITHUB_OUTPUT
             echo "Found signature: $SIG_FILE"
           else
-            echo "No .dmg.sig file found"
+            echo "No .app.tar.gz.sig file found"
             find src-tauri/target/aarch64-apple-darwin/release/bundle -name "*.sig" -type f
           fi
 
       - name: List built artifacts
         run: |
-          echo "=== Finding all DMG and sig files ==="
-          find src-tauri/target/aarch64-apple-darwin/release/bundle -name "*.dmg" -o -name "*.sig" | sort
+          echo "=== Finding all bundle files ==="
+          find src-tauri/target/aarch64-apple-darwin/release/bundle -name "*.dmg" -o -name "*.sig" -o -name "*.tar.gz" | sort
 
-      - name: Upload DMG to Release
+      - name: Upload macOS artifacts to Release
         uses: softprops/action-gh-release@v1
         with:
           tag_name: v${{ needs.create-release.outputs.version }}
           files: |
             src-tauri/target/aarch64-apple-darwin/release/bundle/dmg/*.dmg
-            src-tauri/target/aarch64-apple-darwin/release/bundle/dmg/*.sig
+            src-tauri/target/aarch64-apple-darwin/release/bundle/macos/*.tar.gz
+            src-tauri/target/aarch64-apple-darwin/release/bundle/macos/*.sig
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -245,8 +246,8 @@ jobs:
             "pub_date": "${DATE}",
             "platforms": {
               "darwin-aarch64": {
-                "signature": "${{ needs.build-macos.outputs.dmg_sig }}",
-                "url": "${BASE_URL}/Markdown.Editor_${VERSION}_aarch64.dmg"
+                "signature": "${{ needs.build-macos.outputs.app_sig }}",
+                "url": "${BASE_URL}/Markdown.Editor.app.tar.gz"
               },
               "windows-x86_64": {
                 "signature": "${{ needs.build-windows.outputs.nsis_sig }}",

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -65,28 +65,15 @@ jobs:
 
             ### Downloads
             - **macOS (Apple Silicon)**: `Markdown Editor_x.x.x_aarch64.dmg`
-            - **macOS (Intel)**: `Markdown Editor_x.x.x_x86_64.dmg`
-            - **Windows**: `.msi` or `.exe` installer
-
+  
             ### Installation
             **macOS**: Download the DMG, open it, and drag the app to Applications.
-            **Windows**: Run the installer and follow the prompts.
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   build-macos:
     needs: create-release
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - target: aarch64-apple-darwin
-            runner: macos-latest
-            arch: aarch64
-          - target: x86_64-apple-darwin
-            runner: macos-14
-            arch: x86_64
-    runs-on: ${{ matrix.runner }}
+    runs-on: macos-latest
     permissions:
       contents: write
     steps:
@@ -102,7 +89,7 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
         with:
-          targets: ${{ matrix.target }}
+          targets: aarch64-apple-darwin
 
       - name: Import Apple Developer Certificate
         env:
@@ -128,7 +115,7 @@ jobs:
 
       - name: Build, sign, and notarize Tauri app
         id: build
-        run: npm run tauri build -- --target ${{ matrix.target }}
+        run: npm run tauri build -- --target aarch64-apple-darwin
         env:
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
@@ -139,7 +126,7 @@ jobs:
 
       - name: Verify code signature
         run: |
-          APP_PATH="src-tauri/target/${{ matrix.target }}/release/bundle/macos/Markdown Editor.app"
+          APP_PATH="src-tauri/target/aarch64-apple-darwin/release/bundle/macos/Markdown Editor.app"
           echo "=== Verifying code signature ==="
           codesign --verify --deep --strict --verbose=2 "$APP_PATH" || echo "Warning: Code signature verification failed"
           echo "=== Checking Gatekeeper assessment ==="
@@ -147,7 +134,7 @@ jobs:
 
       - name: Create DMG (fallback if Tauri bundler failed)
         run: |
-          cd src-tauri/target/${{ matrix.target }}/release/bundle/macos
+          cd src-tauri/target/aarch64-apple-darwin/release/bundle/macos
           if ls Markdown\ Editor_*.dmg 1> /dev/null 2>&1; then
             echo "DMG already exists, skipping manual creation"
           else
@@ -156,14 +143,14 @@ jobs:
             cp -R "Markdown Editor.app" "$TEMP_DMG_DIR/"
             ln -s /Applications "$TEMP_DMG_DIR/Applications"
             VERSION=$(node -p "require('../../../../../../package.json').version")
-            hdiutil create -volname "Markdown Editor" -srcfolder "$TEMP_DMG_DIR" -ov -format UDZO "Markdown Editor_${VERSION}_${{ matrix.arch }}.dmg"
+            hdiutil create -volname "Markdown Editor" -srcfolder "$TEMP_DMG_DIR" -ov -format UDZO "Markdown Editor_${VERSION}_aarch64.dmg"
             rm -rf "$TEMP_DMG_DIR"
           fi
 
       - name: List built artifacts
         run: |
           echo "=== Listing bundle directory ==="
-          ls -la src-tauri/target/${{ matrix.target }}/release/bundle/macos/ || echo "Directory not found"
+          ls -la src-tauri/target/aarch64-apple-darwin/release/bundle/macos/ || echo "Directory not found"
           echo "=== Finding all DMG files ==="
           find src-tauri -name "*.dmg" -type f 2>/dev/null || echo "No DMG files found"
 
@@ -171,7 +158,7 @@ jobs:
         uses: softprops/action-gh-release@v1
         with:
           tag_name: v${{ needs.create-release.outputs.version }}
-          files: src-tauri/target/${{ matrix.target }}/release/bundle/macos/*.dmg
+          files: src-tauri/target/aarch64-apple-darwin/release/bundle/macos/*.dmg
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -126,44 +126,16 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Build and sign Tauri app
+      - name: Build, sign, and notarize Tauri app
         id: build
         run: npm run tauri build -- --target ${{ matrix.target }}
         env:
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
           APPLE_SIGNING_IDENTITY: "Developer ID Application: AndrewMorgan Ltd. (NYG9V7955H)"
-
-      - name: Notarize macOS app
-        env:
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_TEAM_ID: NYG9V7955H
           APPLE_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
-        run: |
-          DMG_PATH=$(find src-tauri/target/${{ matrix.target }}/release/bundle -name "*.dmg" -type f | head -1)
-          if [ -n "$DMG_PATH" ]; then
-            echo "Notarizing $DMG_PATH..."
-            xcrun notarytool submit "$DMG_PATH" \
-              --apple-id "$APPLE_ID" \
-              --team-id "$APPLE_TEAM_ID" \
-              --password "$APPLE_PASSWORD" \
-              --wait
-            xcrun stapler staple "$DMG_PATH"
-            echo "Notarization and stapling complete"
-          else
-            echo "No DMG found, attempting to notarize .app bundle..."
-            APP_PATH="src-tauri/target/${{ matrix.target }}/release/bundle/macos/Markdown Editor.app"
-            if [ -d "$APP_PATH" ]; then
-              # Create a zip for notarization
-              ditto -c -k --keepParent "$APP_PATH" "$RUNNER_TEMP/app.zip"
-              xcrun notarytool submit "$RUNNER_TEMP/app.zip" \
-                --apple-id "$APPLE_ID" \
-                --team-id "$APPLE_TEAM_ID" \
-                --password "$APPLE_PASSWORD" \
-                --wait
-              xcrun stapler staple "$APP_PATH"
-            fi
-          fi
 
       - name: Verify code signature
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -23,5 +23,13 @@ dist-ssr
 *.sln
 *.sw?
 
+# Apple Code Signing
+APPLE_SIGNING_SECRETS.md
+*.key
+*.cer
+*.certSigningRequest
+*.p12
+certificate.p12
+
 # Claude Code
 .claude

--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ dist-ssr
 # Apple Code Signing
 APPLE_SIGNING_SECRETS.md
 *.key
+*.key.pub
 *.cer
 *.certSigningRequest
 *.p12

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "markitdown-editor",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "markitdown-editor",
-      "version": "0.1.0",
+      "version": "1.0.0",
       "dependencies": {
         "@codemirror/lang-markdown": "^6.5.0",
         "@radix-ui/react-dialog": "^1.1.15",
@@ -16,6 +16,8 @@
         "@radix-ui/react-slot": "^1.2.4",
         "@radix-ui/react-tabs": "^1.1.13",
         "@tauri-apps/api": "^2.9.1",
+        "@tauri-apps/plugin-process": "^2.3.1",
+        "@tauri-apps/plugin-updater": "^2.10.0",
         "@tiptap/extension-code-block-lowlight": "^3.15.3",
         "@tiptap/extension-document": "^3.15.3",
         "@tiptap/extension-image": "^3.15.3",
@@ -2606,9 +2608,9 @@
       }
     },
     "node_modules/@tauri-apps/api": {
-      "version": "2.9.1",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/api/-/api-2.9.1.tgz",
-      "integrity": "sha512-IGlhP6EivjXHepbBic618GOmiWe4URJiIeZFlB7x3czM0yDHHYviH1Xvoiv4FefdkQtn6v7TuwWCRfOGdnVUGw==",
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/api/-/api-2.10.1.tgz",
+      "integrity": "sha512-hKL/jWf293UDSUN09rR69hrToyIXBb8CjGaWC7gfinvnQrBVvnLr08FeFi38gxtugAVyVcTa5/FD/Xnkb1siBw==",
       "license": "Apache-2.0 OR MIT",
       "funding": {
         "type": "opencollective",
@@ -2830,6 +2832,24 @@
       ],
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/@tauri-apps/plugin-process": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-process/-/plugin-process-2.3.1.tgz",
+      "integrity": "sha512-nCa4fGVaDL/B9ai03VyPOjfAHRHSBz5v6F/ObsB73r/dA3MHHhZtldaDMIc0V/pnUw9ehzr2iEG+XkSEyC0JJA==",
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@tauri-apps/api": "^2.8.0"
+      }
+    },
+    "node_modules/@tauri-apps/plugin-updater": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-updater/-/plugin-updater-2.10.0.tgz",
+      "integrity": "sha512-ljN8jPlnT0aSn8ecYhuBib84alxfMx6Hc8vJSKMJyzGbTPFZAC44T2I1QNFZssgWKrAlofvJqCC6Rr472JWfkQ==",
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@tauri-apps/api": "^2.10.1"
       }
     },
     "node_modules/@tiptap/core": {
@@ -5318,18 +5338,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/detect-libc": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
-      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/detect-node-es": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
@@ -6647,280 +6655,6 @@
       },
       "engines": {
         "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/lightningcss": {
-      "version": "1.30.2",
-      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.30.2.tgz",
-      "integrity": "sha512-utfs7Pr5uJyyvDETitgsaqSyjCb2qNRAtuqUeWIAKztsOYdcACf2KtARYXg2pSvhkt+9NfoaNY7fxjl6nuMjIQ==",
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "detect-libc": "^2.0.3"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      },
-      "optionalDependencies": {
-        "lightningcss-android-arm64": "1.30.2",
-        "lightningcss-darwin-arm64": "1.30.2",
-        "lightningcss-darwin-x64": "1.30.2",
-        "lightningcss-freebsd-x64": "1.30.2",
-        "lightningcss-linux-arm-gnueabihf": "1.30.2",
-        "lightningcss-linux-arm64-gnu": "1.30.2",
-        "lightningcss-linux-arm64-musl": "1.30.2",
-        "lightningcss-linux-x64-gnu": "1.30.2",
-        "lightningcss-linux-x64-musl": "1.30.2",
-        "lightningcss-win32-arm64-msvc": "1.30.2",
-        "lightningcss-win32-x64-msvc": "1.30.2"
-      }
-    },
-    "node_modules/lightningcss-android-arm64": {
-      "version": "1.30.2",
-      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.30.2.tgz",
-      "integrity": "sha512-BH9sEdOCahSgmkVhBLeU7Hc9DWeZ1Eb6wNS6Da8igvUwAe0sqROHddIlvU06q3WyXVEOYDZ6ykBZQnjTbmo4+A==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-darwin-arm64": {
-      "version": "1.30.2",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.30.2.tgz",
-      "integrity": "sha512-ylTcDJBN3Hp21TdhRT5zBOIi73P6/W0qwvlFEk22fkdXchtNTOU4Qc37SkzV+EKYxLouZ6M4LG9NfZ1qkhhBWA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-darwin-x64": {
-      "version": "1.30.2",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.30.2.tgz",
-      "integrity": "sha512-oBZgKchomuDYxr7ilwLcyms6BCyLn0z8J0+ZZmfpjwg9fRVZIR5/GMXd7r9RH94iDhld3UmSjBM6nXWM2TfZTQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-freebsd-x64": {
-      "version": "1.30.2",
-      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.30.2.tgz",
-      "integrity": "sha512-c2bH6xTrf4BDpK8MoGG4Bd6zAMZDAXS569UxCAGcA7IKbHNMlhGQ89eRmvpIUGfKWNVdbhSbkQaWhEoMGmGslA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-linux-arm-gnueabihf": {
-      "version": "1.30.2",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.30.2.tgz",
-      "integrity": "sha512-eVdpxh4wYcm0PofJIZVuYuLiqBIakQ9uFZmipf6LF/HRj5Bgm0eb3qL/mr1smyXIS1twwOxNWndd8z0E374hiA==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-linux-arm64-gnu": {
-      "version": "1.30.2",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.30.2.tgz",
-      "integrity": "sha512-UK65WJAbwIJbiBFXpxrbTNArtfuznvxAJw4Q2ZGlU8kPeDIWEX1dg3rn2veBVUylA2Ezg89ktszWbaQnxD/e3A==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-linux-arm64-musl": {
-      "version": "1.30.2",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.30.2.tgz",
-      "integrity": "sha512-5Vh9dGeblpTxWHpOx8iauV02popZDsCYMPIgiuw97OJ5uaDsL86cnqSFs5LZkG3ghHoX5isLgWzMs+eD1YzrnA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-linux-x64-gnu": {
-      "version": "1.30.2",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.30.2.tgz",
-      "integrity": "sha512-Cfd46gdmj1vQ+lR6VRTTadNHu6ALuw2pKR9lYq4FnhvgBc4zWY1EtZcAc6EffShbb1MFrIPfLDXD6Xprbnni4w==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-linux-x64-musl": {
-      "version": "1.30.2",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.30.2.tgz",
-      "integrity": "sha512-XJaLUUFXb6/QG2lGIW6aIk6jKdtjtcffUT0NKvIqhSBY3hh9Ch+1LCeH80dR9q9LBjG3ewbDjnumefsLsP6aiA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-win32-arm64-msvc": {
-      "version": "1.30.2",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.30.2.tgz",
-      "integrity": "sha512-FZn+vaj7zLv//D/192WFFVA0RgHawIcHqLX9xuWiQt7P0PtdFEVaxgF9rjM/IRYHQXNnk61/H/gb2Ei+kUQ4xQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-win32-x64-msvc": {
-      "version": "1.30.2",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.30.2.tgz",
-      "integrity": "sha512-5g1yc73p+iAkid5phb4oVFMB45417DkRevRbt/El/gKXJk4jid+vPFF/AXbxn05Aky8PapwzZrdJShv5C0avjw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
       }
     },
     "node_modules/lilconfig": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",
-    "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
+    "lint": "eslint . --ext ts,tsx --report-unused-disable-directives",
     "preview": "vite preview",
     "tauri": "tauri",
     "tauri:dev": "tauri dev",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,8 @@
     "@radix-ui/react-slot": "^1.2.4",
     "@radix-ui/react-tabs": "^1.1.13",
     "@tauri-apps/api": "^2.9.1",
+    "@tauri-apps/plugin-process": "^2.3.1",
+    "@tauri-apps/plugin-updater": "^2.10.0",
     "@tiptap/extension-code-block-lowlight": "^3.15.3",
     "@tiptap/extension-document": "^3.15.3",
     "@tiptap/extension-image": "^3.15.3",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -76,6 +76,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
+
+[[package]]
 name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -136,9 +145,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.10.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 dependencies = [
  "serde_core",
 ]
@@ -284,7 +293,7 @@ version = "0.18.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ca26ef0159422fb77631dc9d17b102f253b876fe1586b03b803e63a309b4ee2"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "cairo-sys-rs",
  "glib",
  "libc",
@@ -454,7 +463,7 @@ version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa95a34622365fa5bbf40b20b75dba8dfa8c94c734aea8ac9a5ca38af14316f1"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "core-foundation",
  "core-graphics-types",
  "foreign-types",
@@ -467,7 +476,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d44a101f213f6c4cdc1853d4b78aef6db6bdfa3468798cc1d9912f4735013eb"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "core-foundation",
  "libc",
 ]
@@ -598,6 +607,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
 name = "derive_more"
 version = "0.99.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -653,7 +673,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89a09f22a6c6069a18470eb92d2298acf25463f14256d24778e1230d789a2aec"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "block2",
  "libc",
  "objc2",
@@ -777,6 +797,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
 name = "fdeflate"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -802,6 +838,17 @@ checksum = "38e2275cc4e4fc009b0669731a1e5ab7ebf11f469eaede2bab9309a5b4d6057f"
 dependencies = [
  "memoffset",
  "rustc_version",
+]
+
+[[package]]
+name = "filetime"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "libredox",
 ]
 
 [[package]]
@@ -1140,7 +1187,7 @@ version = "0.18.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "233daaf6e83ae6a12a52055f568f9d7cf4671dabb78ff9560ab6da230ce00ee5"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "futures-channel",
  "futures-core",
  "futures-executor",
@@ -1356,6 +1403,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-rustls"
+version = "0.27.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
 name = "hyper-util"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1405,9 +1468,9 @@ dependencies = [
 
 [[package]]
 name = "ico"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc50b891e4acf8fe0e71ef88ec43ad82ee07b3810ad09de10f1d01f072ed4b98"
+checksum = "3e795dff5605e0f04bff85ca41b51a96b83e80b281e96231bcaaf1ac35103371"
 dependencies = [
  "byteorder",
  "png",
@@ -1658,7 +1721,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b750dcadc39a09dbadd74e118f6dd6598df77fa01df0cfcdc52c28dece74528a"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "serde",
  "unicode-segmentation",
 ]
@@ -1707,9 +1770,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.180"
+version = "0.2.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
+checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 
 [[package]]
 name = "libloading"
@@ -1727,9 +1790,16 @@ version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "libc",
+ "redox_syscall 0.7.3",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
@@ -1773,6 +1843,8 @@ dependencies = [
  "tauri-plugin-dialog",
  "tauri-plugin-fs",
  "tauri-plugin-log",
+ "tauri-plugin-process",
+ "tauri-plugin-updater",
 ]
 
 [[package]]
@@ -1828,6 +1900,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "minisign-verify"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22f9645cb765ea72b8111f36c522475d2daa0d22c957a9826437e97534bc4e9e"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1875,7 +1953,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3f42e7bbe13d351b6bead8286a43aac9534b82bd3cc43e47037f012ebfd62d4"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "jni-sys",
  "log",
  "ndk-sys",
@@ -1973,40 +2051,10 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "block2",
- "libc",
  "objc2",
- "objc2-cloud-kit",
- "objc2-core-data",
  "objc2-core-foundation",
- "objc2-core-graphics",
- "objc2-core-image",
- "objc2-core-text",
- "objc2-core-video",
- "objc2-foundation",
- "objc2-quartz-core",
-]
-
-[[package]]
-name = "objc2-cloud-kit"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73ad74d880bb43877038da939b7427bba67e9dd42004a18b809ba7d87cee241c"
-dependencies = [
- "bitflags 2.10.0",
- "objc2",
- "objc2-foundation",
-]
-
-[[package]]
-name = "objc2-core-data"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b402a653efbb5e82ce4df10683b6b28027616a2715e90009947d50b8dd298fa"
-dependencies = [
- "bitflags 2.10.0",
- "objc2",
  "objc2-foundation",
 ]
 
@@ -2016,7 +2064,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "dispatch2",
  "objc2",
 ]
@@ -2027,45 +2075,10 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "dispatch2",
  "objc2",
  "objc2-core-foundation",
- "objc2-io-surface",
-]
-
-[[package]]
-name = "objc2-core-image"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5d563b38d2b97209f8e861173de434bd0214cf020e3423a52624cd1d989f006"
-dependencies = [
- "objc2",
- "objc2-foundation",
-]
-
-[[package]]
-name = "objc2-core-text"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cde0dfb48d25d2b4862161a4d5fcc0e3c24367869ad306b0c9ec0073bfed92d"
-dependencies = [
- "bitflags 2.10.0",
- "objc2",
- "objc2-core-foundation",
- "objc2-core-graphics",
-]
-
-[[package]]
-name = "objc2-core-video"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d425caf1df73233f29fd8a5c3e5edbc30d2d4307870f802d18f00d83dc5141a6"
-dependencies = [
- "bitflags 2.10.0",
- "objc2",
- "objc2-core-foundation",
- "objc2-core-graphics",
  "objc2-io-surface",
 ]
 
@@ -2090,7 +2103,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "block2",
  "libc",
  "objc2",
@@ -2103,19 +2116,21 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "objc2",
  "objc2-core-foundation",
 ]
 
 [[package]]
-name = "objc2-javascript-core"
+name = "objc2-osa-kit"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a1e6550c4caed348956ce3370c9ffeca70bb1dbed4fa96112e7c6170e074586"
+checksum = "f112d1746737b0da274ef79a23aac283376f335f4095a083a267a082f21db0c0"
 dependencies = [
+ "bitflags 2.11.0",
  "objc2",
- "objc2-core-foundation",
+ "objc2-app-kit",
+ "objc2-foundation",
 ]
 
 [[package]]
@@ -2124,21 +2139,10 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96c1358452b371bf9f104e21ec536d37a650eb10f7ee379fff67d2e08d537f1f"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "objc2",
  "objc2-core-foundation",
  "objc2-foundation",
-]
-
-[[package]]
-name = "objc2-security"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "709fe137109bd1e8b5a99390f77a7d8b2961dafc1a1c5db8f2e60329ad6d895a"
-dependencies = [
- "bitflags 2.10.0",
- "objc2",
- "objc2-core-foundation",
 ]
 
 [[package]]
@@ -2147,7 +2151,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d87d638e33c06f577498cbcc50491496a3ed4246998a7fbba7ccb98b1e7eab22"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "objc2",
  "objc2-core-foundation",
  "objc2-foundation",
@@ -2159,14 +2163,12 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2e5aaab980c433cf470df9d7af96a7b46a9d892d521a2cbbb2f8a4c16751e7f"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "block2",
  "objc2",
  "objc2-app-kit",
  "objc2-core-foundation",
  "objc2-foundation",
- "objc2-javascript-core",
- "objc2-security",
 ]
 
 [[package]]
@@ -2176,10 +2178,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "osakit"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "732c71caeaa72c065bb69d7ea08717bd3f4863a4f451402fc9513e29dbd5261b"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+ "objc2-osa-kit",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+]
 
 [[package]]
 name = "pango"
@@ -2224,7 +2246,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.5.18",
  "smallvec",
  "windows-link 0.2.1",
 ]
@@ -2654,7 +2676,16 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce70a74e890531977d37e532c34d45e9055d2409ed08ddba14529471ed0be16"
+dependencies = [
+ "bitflags 2.11.0",
 ]
 
 [[package]]
@@ -2728,9 +2759,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.12.28"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -2740,16 +2771,20 @@ dependencies = [
  "http-body",
  "http-body-util",
  "hyper",
+ "hyper-rustls",
  "hyper-util",
  "js-sys",
  "log",
  "percent-encoding",
  "pin-project-lite",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
  "serde",
  "serde_json",
- "serde_urlencoded",
  "sync_wrapper",
  "tokio",
+ "tokio-rustls",
  "tokio-util",
  "tower",
  "tower-http",
@@ -2783,6 +2818,20 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
  "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2840,16 +2889,96 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags 2.11.0",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
+dependencies = [
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
+dependencies = [
+ "core-foundation",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
-
-[[package]]
-name = "ryu"
-version = "1.0.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a50f4cf475b65d88e057964e0e9bb1f0aa9bbb2036dc65c64596b42932536984"
 
 [[package]]
 name = "same-file"
@@ -2858,6 +2987,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2922,6 +3060,29 @@ name = "seahash"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags 2.11.0",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "selectors"
@@ -3044,18 +3205,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776"
 dependencies = [
  "serde_core",
-]
-
-[[package]]
-name = "serde_urlencoded"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
-dependencies = [
- "form_urlencoded",
- "itoa",
- "ryu",
- "serde",
 ]
 
 [[package]]
@@ -3199,7 +3348,7 @@ dependencies = [
  "objc2-foundation",
  "objc2-quartz-core",
  "raw-window-handle",
- "redox_syscall",
+ "redox_syscall 0.5.18",
  "tracing",
  "wasm-bindgen",
  "web-sys",
@@ -3268,6 +3417,12 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "swift-rs"
@@ -3341,7 +3496,7 @@ version = "0.34.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3a753bdc39c07b192151523a3f77cd0394aa75413802c883a0f6f6a0e5ee2e7"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "block2",
  "core-foundation",
  "core-graphics",
@@ -3393,6 +3548,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
+name = "tar"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
+
+[[package]]
 name = "target-lexicon"
 version = "0.12.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3400,9 +3566,9 @@ checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
 
 [[package]]
 name = "tauri"
-version = "2.9.5"
+version = "2.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a3868da5508446a7cd08956d523ac3edf0a8bc20bf7e4038f9a95c2800d2033"
+checksum = "da77cc00fb9028caf5b5d4650f75e31f1ef3693459dfca7f7e506d1ecef0ba2d"
 dependencies = [
  "anyhow",
  "bytes",
@@ -3451,9 +3617,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-build"
-version = "2.5.3"
+version = "2.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17fcb8819fd16463512a12f531d44826ce566f486d7ccd211c9c8cebdaec4e08"
+checksum = "4bbc990d1dbf57a8e1c7fa2327f2a614d8b757805603c1b9ba5c81bade09fd4d"
 dependencies = [
  "anyhow",
  "cargo_toml",
@@ -3473,9 +3639,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-codegen"
-version = "2.5.2"
+version = "2.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fa9844cefcf99554a16e0a278156ae73b0d8680bbc0e2ad1e4287aadd8489cf"
+checksum = "d4a24476afd977c5d5d169f72425868613d82747916dd29e0a357c84c4bd6d29"
 dependencies = [
  "base64 0.22.1",
  "brotli",
@@ -3500,9 +3666,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-macros"
-version = "2.5.2"
+version = "2.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3764a12f886d8245e66b7ee9b43ccc47883399be2019a61d80cf0f4117446fde"
+checksum = "d39b349a98dadaffebb73f0a40dcd1f23c999211e5a2e744403db384d0c33de7"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -3592,10 +3758,53 @@ dependencies = [
 ]
 
 [[package]]
-name = "tauri-runtime"
-version = "2.9.2"
+name = "tauri-plugin-process"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87f766fe9f3d1efc4b59b17e7a891ad5ed195fa8d23582abb02e6c9a01137892"
+checksum = "d55511a7bf6cd70c8767b02c97bf8134fa434daf3926cfc1be0a0f94132d165a"
+dependencies = [
+ "tauri",
+ "tauri-plugin",
+]
+
+[[package]]
+name = "tauri-plugin-updater"
+version = "2.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fe8e9bebd88fc222938ffdfbdcfa0307081423bd01e3252fc337d8bde81fc61"
+dependencies = [
+ "base64 0.22.1",
+ "dirs",
+ "flate2",
+ "futures-util",
+ "http",
+ "infer",
+ "log",
+ "minisign-verify",
+ "osakit",
+ "percent-encoding",
+ "reqwest",
+ "rustls",
+ "semver",
+ "serde",
+ "serde_json",
+ "tar",
+ "tauri",
+ "tauri-plugin",
+ "tempfile",
+ "thiserror 2.0.18",
+ "time",
+ "tokio",
+ "url",
+ "windows-sys 0.60.2",
+ "zip",
+]
+
+[[package]]
+name = "tauri-runtime"
+version = "2.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2826d79a3297ed08cd6ea7f412644ef58e32969504bc4fbd8d7dbeabc4445ea2"
 dependencies = [
  "cookie",
  "dpi",
@@ -3618,9 +3827,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-runtime-wry"
-version = "2.9.3"
+version = "2.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "187a3f26f681bdf028f796ccf57cf478c1ee422c50128e5a0a6ebeb3f5910065"
+checksum = "e11ea2e6f801d275fdd890d6c9603736012742a1c33b96d0db788c9cdebf7f9e"
 dependencies = [
  "gtk",
  "http",
@@ -3628,7 +3837,6 @@ dependencies = [
  "log",
  "objc2",
  "objc2-app-kit",
- "objc2-foundation",
  "once_cell",
  "percent-encoding",
  "raw-window-handle",
@@ -3645,9 +3853,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-utils"
-version = "2.8.1"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76a423c51176eb3616ee9b516a9fa67fed5f0e78baaba680e44eb5dd2cc37490"
+checksum = "219a1f983a2af3653f75b5747f76733b0da7ff03069c7a41901a5eb3ace4557d"
 dependencies = [
  "anyhow",
  "brotli",
@@ -3690,6 +3898,19 @@ dependencies = [
  "dunce",
  "embed-resource",
  "toml 0.9.11+spec-1.1.0",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.3.4",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3813,6 +4034,16 @@ dependencies = [
  "pin-project-lite",
  "socket2",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
 ]
 
 [[package]]
@@ -3945,7 +4176,7 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "bytes",
  "futures-util",
  "http",
@@ -4080,6 +4311,12 @@ name = "unicode-segmentation"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
@@ -4275,9 +4512,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-streams"
-version = "0.4.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+checksum = "9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb"
 dependencies = [
  "futures-util",
  "js-sys",
@@ -4298,9 +4535,9 @@ dependencies = [
 
 [[package]]
 name = "webkit2gtk"
-version = "2.0.1"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76b1bc1e54c581da1e9f179d0b38512ba358fb1af2d634a1affe42e37172361a"
+checksum = "a1027150013530fb2eaf806408df88461ae4815a45c541c8975e61d6f2fc4793"
 dependencies = [
  "bitflags 1.3.2",
  "cairo-rs",
@@ -4322,9 +4559,9 @@ dependencies = [
 
 [[package]]
 name = "webkit2gtk-sys"
-version = "2.0.1"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62daa38afc514d1f8f12b8693d30d5993ff77ced33ce30cd04deebc267a6d57c"
+checksum = "916a5f65c2ef0dfe12fff695960a2ec3d4565359fdbb2e9943c974e06c734ea5"
 dependencies = [
  "bitflags 1.3.2",
  "cairo-sys-rs",
@@ -4338,6 +4575,15 @@ dependencies = [
  "pkg-config",
  "soup3-sys",
  "system-deps",
+]
+
+[[package]]
+name = "webpki-root-certs"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "804f18a4ac2676ffb4e8b5b5fa9ae38af06df08162314f96a68d2a363e21a8ca"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -4568,6 +4814,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
 dependencies = [
  "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -4843,9 +5098,9 @@ checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 
 [[package]]
 name = "wry"
-version = "0.53.5"
+version = "0.54.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "728b7d4c8ec8d81cab295e0b5b8a4c263c0d41a785fb8f8c4df284e5411140a2"
+checksum = "bb26159b420aa77684589a744ae9a9461a95395b848764ad12290a14d960a11a"
 dependencies = [
  "base64 0.22.1",
  "block2",
@@ -4917,6 +5172,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix",
+]
+
+[[package]]
 name = "yoke"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4981,6 +5246,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+
+[[package]]
 name = "zerotrie"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5011,6 +5282,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.114",
+]
+
+[[package]]
+name = "zip"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa8cd6af31c3b31c6631b8f483848b91589021b28fffe50adada48d4f4d2ed1"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "indexmap 2.13.0",
+ "memchr",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -25,3 +25,5 @@ tauri = { version = "2.9.5", features = [] }
 tauri-plugin-log = "2"
 tauri-plugin-dialog = "2"
 tauri-plugin-fs = "2"
+tauri-plugin-updater = "2.10.0"
+tauri-plugin-process = "2.3.1"

--- a/src-tauri/Entitlements.plist
+++ b/src-tauri/Entitlements.plist
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+    <true/>
+    <key>com.apple.security.cs.allow-dyld-environment-variables</key>
+    <true/>
+    <key>com.apple.security.network.client</key>
+    <true/>
+    <key>com.apple.security.files.user-selected.read-write</key>
+    <true/>
+</dict>
+</plist>

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -8,6 +8,8 @@
   "permissions": [
     "core:default",
     "dialog:default",
-    "fs:default"
+    "fs:default",
+    "updater:default",
+    "process:default"
   ]
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,11 +1,16 @@
 use serde::{Deserialize, Serialize};
 use std::fs;
 use std::path::PathBuf;
+use std::sync::Mutex;
 use tauri::{Emitter, Manager};
 use tauri_plugin_dialog::DialogExt;
 
 const MAX_RECENT_FILES: usize = 10;
 const RECENT_FILES_FILENAME: &str = "recent_files.json";
+
+/// Holds file paths received via macOS Apple Events before the frontend is ready
+#[derive(Default)]
+struct PendingFiles(Mutex<Vec<String>>);
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct FileResult {
@@ -182,32 +187,52 @@ fn clear_recent_files(app: tauri::AppHandle) -> Result<(), String> {
     save_recent_paths(&app, &[])
 }
 
-/// Get the file path if app was launched with a file argument
-#[tauri::command]
-fn get_opened_file() -> Option<FileResult> {
-    let args: Vec<String> = std::env::args().collect();
-
-    // Check if a file path was passed as argument (skip the first arg which is the executable)
-    for arg in args.iter().skip(1) {
-        let path = PathBuf::from(arg);
-        if path.exists() && path.is_file() {
-            if let Some(ext) = path.extension() {
-                let ext_str = ext.to_string_lossy().to_lowercase();
-                if ext_str == "md" || ext_str == "markdown" {
-                    if let Ok(content) = fs::read_to_string(&path) {
-                        let name = path
-                            .file_name()
-                            .and_then(|n| n.to_str())
-                            .unwrap_or("untitled.md")
-                            .to_string();
-                        return Some(FileResult {
-                            path: path.to_string_lossy().to_string(),
-                            name,
-                            content,
-                        });
-                    }
+/// Read a markdown file path into a FileResult if valid
+fn read_markdown_path(path_str: &str) -> Option<FileResult> {
+    let path = PathBuf::from(path_str);
+    if path.exists() && path.is_file() {
+        if let Some(ext) = path.extension() {
+            let ext_str = ext.to_string_lossy().to_lowercase();
+            if ext_str == "md" || ext_str == "markdown" {
+                if let Ok(content) = fs::read_to_string(&path) {
+                    let name = path
+                        .file_name()
+                        .and_then(|n| n.to_str())
+                        .unwrap_or("untitled.md")
+                        .to_string();
+                    return Some(FileResult {
+                        path: path.to_string_lossy().to_string(),
+                        name,
+                        content,
+                    });
                 }
             }
+        }
+    }
+    None
+}
+
+/// Get the file path if app was launched with a file argument or via macOS file association.
+/// Checks buffered Apple Event paths first, then falls back to CLI args.
+/// Drains the buffer so files are only returned once.
+#[tauri::command]
+fn get_opened_file(state: tauri::State<'_, PendingFiles>) -> Option<FileResult> {
+    // Check buffered paths from Apple Events (macOS "Open With" / double-click)
+    {
+        let mut pending = state.0.lock().unwrap();
+        if let Some(path_str) = pending.pop() {
+            pending.clear(); // Only open one file at startup
+            if let Some(result) = read_markdown_path(&path_str) {
+                return Some(result);
+            }
+        }
+    }
+
+    // Fallback: check CLI arguments
+    let args: Vec<String> = std::env::args().collect();
+    for arg in args.iter().skip(1) {
+        if let Some(result) = read_markdown_path(arg) {
+            return Some(result);
         }
     }
     None
@@ -218,6 +243,7 @@ pub fn run() {
     tauri::Builder::default()
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_fs::init())
+        .manage(PendingFiles::default())
         .setup(|app| {
             if cfg!(debug_assertions) {
                 app.handle().plugin(
@@ -242,30 +268,26 @@ pub fn run() {
         .expect("error while building tauri application")
         .run(|_app, _event| {
             #[cfg(target_os = "macos")]
-            if let tauri::RunEvent::Opened { urls } = _event {
-                for url in urls {
-                    // file:// URLs from macOS file associations
-                    if let Ok(path) = url.to_file_path() {
-                        if let Some(ext) = path.extension() {
-                            let ext_str = ext.to_string_lossy().to_lowercase();
-                            if ext_str == "md" || ext_str == "markdown" {
-                                if let Ok(content) = fs::read_to_string(&path) {
-                                    let name = path
-                                        .file_name()
-                                        .and_then(|n| n.to_str())
-                                        .unwrap_or("untitled.md")
-                                        .to_string();
-                                    let file = FileResult {
-                                        path: path.to_string_lossy().to_string(),
-                                        name,
-                                        content,
-                                    };
-                                    let _ = _app.emit("open-file", &file);
-                                }
-                            }
+            if let tauri::RunEvent::Opened { urls } = &_event {
+                let paths: Vec<String> = urls
+                    .iter()
+                    .filter_map(|url| {
+                        if url.scheme() == "file" {
+                            url.to_file_path().ok().map(|p| p.to_string_lossy().to_string())
+                        } else {
+                            Some(url.to_string())
                         }
-                    }
+                    })
+                    .collect();
+
+                // Buffer paths for get_opened_file (handles startup race condition)
+                if let Some(state) = _app.try_state::<PendingFiles>() {
+                    let mut pending = state.0.lock().unwrap();
+                    pending.extend(paths.clone());
                 }
+
+                // Also emit event for when the app is already running with files open
+                let _ = _app.emit("open-file", &paths);
             }
         });
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -8,9 +8,14 @@ use tauri_plugin_dialog::DialogExt;
 const MAX_RECENT_FILES: usize = 10;
 const RECENT_FILES_FILENAME: &str = "recent_files.json";
 
-/// Holds file paths received via macOS Apple Events before the frontend is ready
+/// Holds file paths received via macOS Apple Events before the frontend is ready.
+/// Once the frontend calls get_opened_file, `ready` is set to true and subsequent
+/// events are emitted directly instead of being buffered.
 #[derive(Default)]
-struct PendingFiles(Mutex<Vec<String>>);
+struct PendingFiles {
+    paths: Mutex<Vec<String>>,
+    ready: Mutex<bool>,
+}
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct FileResult {
@@ -214,14 +219,17 @@ fn read_markdown_path(path_str: &str) -> Option<FileResult> {
 
 /// Get the file path if app was launched with a file argument or via macOS file association.
 /// Checks buffered Apple Event paths first, then falls back to CLI args.
-/// Drains the buffer so files are only returned once.
+/// Marks the frontend as ready so subsequent RunEvent::Opened events are emitted directly.
 #[tauri::command]
 fn get_opened_file(state: tauri::State<'_, PendingFiles>) -> Option<FileResult> {
+    // Mark frontend as ready — future events will be emitted directly
+    *state.ready.lock().unwrap() = true;
+
     // Check buffered paths from Apple Events (macOS "Open With" / double-click)
     {
-        let mut pending = state.0.lock().unwrap();
+        let mut pending = state.paths.lock().unwrap();
         if let Some(path_str) = pending.pop() {
-            pending.clear(); // Only open one file at startup
+            pending.clear();
             if let Some(result) = read_markdown_path(&path_str) {
                 return Some(result);
             }
@@ -282,14 +290,17 @@ pub fn run() {
                     })
                     .collect();
 
-                // Buffer paths for get_opened_file (handles startup race condition)
                 if let Some(state) = _app.try_state::<PendingFiles>() {
-                    let mut pending = state.0.lock().unwrap();
-                    pending.extend(paths.clone());
+                    let is_ready = *state.ready.lock().unwrap();
+                    if is_ready {
+                        // Frontend is ready — emit event directly
+                        let _ = _app.emit("open-file", &paths);
+                    } else {
+                        // Frontend not ready yet — buffer for get_opened_file
+                        let mut pending = state.paths.lock().unwrap();
+                        pending.extend(paths);
+                    }
                 }
-
-                // Also emit event for when the app is already running with files open
-                let _ = _app.emit("open-file", &paths);
             }
         });
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -243,6 +243,8 @@ pub fn run() {
     tauri::Builder::default()
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_fs::init())
+        .plugin(tauri_plugin_updater::Builder::new().build())
+        .plugin(tauri_plugin_process::init())
         .manage(PendingFiles::default())
         .setup(|app| {
             if cfg!(debug_assertions) {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -240,8 +240,9 @@ pub fn run() {
         ])
         .build(tauri::generate_context!())
         .expect("error while building tauri application")
-        .run(|app, event| {
-            if let tauri::RunEvent::Opened { urls } = event {
+        .run(|_app, _event| {
+            #[cfg(target_os = "macos")]
+            if let tauri::RunEvent::Opened { urls } = _event {
                 for url in urls {
                     // file:// URLs from macOS file associations
                     if let Ok(path) = url.to_file_path() {
@@ -259,7 +260,7 @@ pub fn run() {
                                         name,
                                         content,
                                     };
-                                    let _ = app.emit("open-file", &file);
+                                    let _ = _app.emit("open-file", &file);
                                 }
                             }
                         }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 use std::fs;
 use std::path::PathBuf;
-use tauri::Manager;
+use tauri::{Emitter, Manager};
 use tauri_plugin_dialog::DialogExt;
 
 const MAX_RECENT_FILES: usize = 10;
@@ -238,6 +238,33 @@ pub fn run() {
             add_recent_file,
             clear_recent_files
         ])
-        .run(tauri::generate_context!())
-        .expect("error while running tauri application");
+        .build(tauri::generate_context!())
+        .expect("error while building tauri application")
+        .run(|app, event| {
+            if let tauri::RunEvent::Opened { urls } = event {
+                for url in urls {
+                    // file:// URLs from macOS file associations
+                    if let Ok(path) = url.to_file_path() {
+                        if let Some(ext) = path.extension() {
+                            let ext_str = ext.to_string_lossy().to_lowercase();
+                            if ext_str == "md" || ext_str == "markdown" {
+                                if let Ok(content) = fs::read_to_string(&path) {
+                                    let name = path
+                                        .file_name()
+                                        .and_then(|n| n.to_str())
+                                        .unwrap_or("untitled.md")
+                                        .to_string();
+                                    let file = FileResult {
+                                        path: path.to_string_lossy().to_string(),
+                                        name,
+                                        content,
+                                    };
+                                    let _ = app.emit("open-file", &file);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        });
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -38,8 +38,8 @@
     "macOS": {
       "minimumSystemVersion": "10.13",
       "exceptionDomain": null,
-      "signingIdentity": null,
-      "providerShortName": null,
+      "signingIdentity": "Developer ID Application: AndrewMorgan Ltd. (NYG9V7955H)",
+      "providerShortName": "NYG9V7955H",
       "entitlements": null
     },
     "fileAssociations": [

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -55,6 +55,15 @@
     "longDescription": "A beautiful, minimalistic markdown editor with live preview, split view editing, and Mermaid diagram support.",
     "copyright": "© 2026 DonkeyWork",
     "category": "DeveloperTool",
-    "publisher": "DonkeyWork"
+    "publisher": "DonkeyWork",
+    "createUpdaterArtifacts": "v1Compatible"
+  },
+  "plugins": {
+    "updater": {
+      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDk3RTdFQjBBMENEQzQ5REQKUldUZFNkd01DdXZubDZWc0dRUVNUN1ZldEhDY3hqZ2I5cVdpWWZnUjJYeDZVR1dJaDZhdit2dDcK",
+      "endpoints": [
+        "https://github.com/andyjmorgan/DonkeyWork-MarkdownEditor/releases/latest/download/latest.json"
+      ]
+    }
   }
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -40,7 +40,7 @@
       "exceptionDomain": null,
       "signingIdentity": "Developer ID Application: AndrewMorgan Ltd. (NYG9V7955H)",
       "providerShortName": "NYG9V7955H",
-      "entitlements": null
+      "entitlements": "Entitlements.plist"
     },
     "fileAssociations": [
       {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import { EditorView } from './components/editor/EditorView'
 import { useFileStore } from './store'
 import { useThemeStore } from './store'
 import { exportToPdf } from './lib/pdf/exporter'
+import { isTauri } from './lib/storage/provider'
 
 function App() {
   const tabs = useFileStore((state) => state.tabs)
@@ -20,6 +21,32 @@ function App() {
       document.documentElement.classList.remove('dark')
     }
   }, [theme])
+
+  // Check for updates on launch (Tauri only)
+  useEffect(() => {
+    if (!isTauri()) return
+
+    const checkForUpdates = async () => {
+      try {
+        const { check } = await import('@tauri-apps/plugin-updater')
+        const update = await check()
+        if (update) {
+          const confirmed = window.confirm(
+            `A new version (${update.version}) is available. Would you like to update now?`
+          )
+          if (confirmed) {
+            await update.downloadAndInstall()
+            const { relaunch } = await import('@tauri-apps/plugin-process')
+            await relaunch()
+          }
+        }
+      } catch (error) {
+        console.error('Failed to check for updates:', error)
+      }
+    }
+
+    checkForUpdates()
+  }, [])
 
   const handleDownloadMarkdown = useCallback(() => {
     if (!activeFile) return

--- a/src/components/editor/EditorView.tsx
+++ b/src/components/editor/EditorView.tsx
@@ -7,7 +7,8 @@ import { NewFileDialog } from '@/components/dialogs/NewFileDialog'
 import { useFileStore } from '@/store'
 import { useFileOperations } from '@/hooks/useFileOperations'
 import { useMediaQuery } from '@/hooks/useMediaQuery'
-import { Download } from 'lucide-react'
+import { isTauri } from '@/lib/storage/provider'
+import { Download, FileOutput } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import {
   DropdownMenu,
@@ -28,6 +29,7 @@ export function EditorView({ onDownloadMarkdown, onExportPdf }: EditorViewProps)
   const [viewMode, setViewMode] = useState<ViewMode>('split')
   const [isNewFileDialogOpen, setIsNewFileDialogOpen] = useState(false)
   const isMobile = useMediaQuery('(max-width: 768px)')
+  const isDesktop = isTauri()
 
   // Force code or preview mode on mobile (no split)
   useEffect(() => {
@@ -119,22 +121,29 @@ export function EditorView({ onDownloadMarkdown, onExportPdf }: EditorViewProps)
           {viewMode !== 'split' && (
             <div className="flex items-center gap-2">
               <ViewModeToggle viewMode={viewMode} onViewModeChange={setViewMode} />
-              <DropdownMenu>
-                <DropdownMenuTrigger asChild>
-                  <Button variant="ghost" size="sm" className="h-7 px-3 text-xs">
-                    <Download className="h-3.5 w-3.5 mr-1.5" />
-                    Download
-                  </Button>
-                </DropdownMenuTrigger>
-                <DropdownMenuContent align="end">
-                  <DropdownMenuItem onClick={onDownloadMarkdown}>
-                    Download as Markdown
-                  </DropdownMenuItem>
-                  <DropdownMenuItem onClick={onExportPdf}>
-                    Export as PDF
-                  </DropdownMenuItem>
-                </DropdownMenuContent>
-              </DropdownMenu>
+              {isDesktop ? (
+                <Button variant="ghost" size="sm" className="h-7 px-3 text-xs" onClick={onExportPdf}>
+                  <FileOutput className="h-3.5 w-3.5 mr-1.5" />
+                  Export PDF
+                </Button>
+              ) : (
+                <DropdownMenu>
+                  <DropdownMenuTrigger asChild>
+                    <Button variant="ghost" size="sm" className="h-7 px-3 text-xs">
+                      <Download className="h-3.5 w-3.5 mr-1.5" />
+                      Download
+                    </Button>
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent align="end">
+                    <DropdownMenuItem onClick={onDownloadMarkdown}>
+                      Download as Markdown
+                    </DropdownMenuItem>
+                    <DropdownMenuItem onClick={onExportPdf}>
+                      Export as PDF
+                    </DropdownMenuItem>
+                  </DropdownMenuContent>
+                </DropdownMenu>
+              )}
             </div>
           )}
         </div>
@@ -169,22 +178,29 @@ export function EditorView({ onDownloadMarkdown, onExportPdf }: EditorViewProps)
           {viewMode !== 'split' && (
             <div className="flex items-center gap-2">
               <ViewModeToggle viewMode={viewMode} onViewModeChange={setViewMode} />
-              <DropdownMenu>
-                <DropdownMenuTrigger asChild>
-                  <Button variant="ghost" size="sm" className="h-7 px-3 text-xs">
-                    <Download className="h-3.5 w-3.5 mr-1.5" />
-                    Download
-                  </Button>
-                </DropdownMenuTrigger>
-                <DropdownMenuContent align="end">
-                  <DropdownMenuItem onClick={onDownloadMarkdown}>
-                    Download as Markdown
-                  </DropdownMenuItem>
-                  <DropdownMenuItem onClick={onExportPdf}>
-                    Export as PDF
-                  </DropdownMenuItem>
-                </DropdownMenuContent>
-              </DropdownMenu>
+              {isDesktop ? (
+                <Button variant="ghost" size="sm" className="h-7 px-3 text-xs" onClick={onExportPdf}>
+                  <FileOutput className="h-3.5 w-3.5 mr-1.5" />
+                  Export PDF
+                </Button>
+              ) : (
+                <DropdownMenu>
+                  <DropdownMenuTrigger asChild>
+                    <Button variant="ghost" size="sm" className="h-7 px-3 text-xs">
+                      <Download className="h-3.5 w-3.5 mr-1.5" />
+                      Download
+                    </Button>
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent align="end">
+                    <DropdownMenuItem onClick={onDownloadMarkdown}>
+                      Download as Markdown
+                    </DropdownMenuItem>
+                    <DropdownMenuItem onClick={onExportPdf}>
+                      Export as PDF
+                    </DropdownMenuItem>
+                  </DropdownMenuContent>
+                </DropdownMenu>
+              )}
             </div>
           )}
         </div>

--- a/src/components/layout/AppLayout.tsx
+++ b/src/components/layout/AppLayout.tsx
@@ -4,6 +4,7 @@ import { ThemeToggle } from '@/components/common/ThemeToggle'
 import { Github } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { useAutosave } from '@/hooks/useAutosave'
+import { isTauri } from '@/lib/storage/provider'
 
 interface AppLayoutProps {
   children: ReactNode
@@ -14,38 +15,42 @@ export function AppLayout({ children, showTabs = false }: AppLayoutProps) {
   // Run autosave hook (no UI, just side effects)
   useAutosave()
 
+  const isDesktop = isTauri()
+
   return (
     <div className="flex flex-col h-screen bg-background text-foreground">
-      {/* Header */}
-      <header className="border-b border-border">
-        <div className="px-4 py-3 flex items-center justify-between">
-          <div className="flex items-center gap-3">
-            <img
-              src="/donkeywork.png"
-              alt="DonkeyWork Logo"
-              className="w-7 h-7"
-            />
-            <h1 className="text-xl font-semibold">Markdown Editor</h1>
-          </div>
-          <div className="flex items-center gap-2">
-            <Button
-              variant="ghost"
-              size="icon"
-              asChild
-            >
-              <a
-                href="https://github.com/andyjmorgan/DonkeyWork-MarkdownEditor"
-                target="_blank"
-                rel="noopener noreferrer"
-                title="View on GitHub"
+      {/* Header - hidden in desktop app */}
+      {!isDesktop && (
+        <header className="border-b border-border">
+          <div className="px-4 py-3 flex items-center justify-between">
+            <div className="flex items-center gap-3">
+              <img
+                src="/donkeywork.png"
+                alt="DonkeyWork Logo"
+                className="w-7 h-7"
+              />
+              <h1 className="text-xl font-semibold">Markdown Editor</h1>
+            </div>
+            <div className="flex items-center gap-2">
+              <Button
+                variant="ghost"
+                size="icon"
+                asChild
               >
-                <Github className="h-5 w-5" />
-              </a>
-            </Button>
-            <ThemeToggle />
+                <a
+                  href="https://github.com/andyjmorgan/DonkeyWork-MarkdownEditor"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  title="View on GitHub"
+                >
+                  <Github className="h-5 w-5" />
+                </a>
+              </Button>
+              <ThemeToggle />
+            </div>
           </div>
-        </div>
-      </header>
+        </header>
+      )}
 
       {/* Tab bar */}
       {showTabs && <TabBar />}

--- a/src/hooks/useFileOperations.ts
+++ b/src/hooks/useFileOperations.ts
@@ -41,12 +41,19 @@ export function useFileOperations() {
           console.error('Failed to check for opened file:', error)
         }
 
-        // Listen for file-open events (macOS file associations while app is running)
+        // Listen for file-open events (macOS file associations while app is already running)
         try {
           const { listen } = await import('@tauri-apps/api/event')
           const { invoke } = await import('@tauri-apps/api/core')
           listen<string[]>('open-file', async (event) => {
             for (const filePath of event.payload) {
+              // Skip if this file is already open
+              const currentFiles = useFileStore.getState().files
+              const alreadyOpen = Array.from(currentFiles.values()).some(
+                (f) => f.filePath === filePath
+              )
+              if (alreadyOpen) continue
+
               try {
                 const result = await invoke<{ path: string; name: string; content: string }>('read_file', { path: filePath })
                 const file: MarkdownFile = {

--- a/src/hooks/useFileOperations.ts
+++ b/src/hooks/useFileOperations.ts
@@ -41,21 +41,28 @@ export function useFileOperations() {
           console.error('Failed to check for opened file:', error)
         }
 
-        // Listen for file-open events (macOS file associations)
+        // Listen for file-open events (macOS file associations while app is running)
         try {
           const { listen } = await import('@tauri-apps/api/event')
-          listen<{ path: string; name: string; content: string }>('open-file', (event) => {
-            const openedFile = event.payload
-            const file: MarkdownFile = {
-              id: nanoid(),
-              name: openedFile.name,
-              content: openedFile.content,
-              lastModified: Date.now(),
-              isDirty: false,
-              filePath: openedFile.path,
-              isUntitled: false,
+          const { invoke } = await import('@tauri-apps/api/core')
+          listen<string[]>('open-file', async (event) => {
+            for (const filePath of event.payload) {
+              try {
+                const result = await invoke<{ path: string; name: string; content: string }>('read_file', { path: filePath })
+                const file: MarkdownFile = {
+                  id: nanoid(),
+                  name: result.name,
+                  content: result.content,
+                  lastModified: Date.now(),
+                  isDirty: false,
+                  filePath: result.path,
+                  isUntitled: false,
+                }
+                addFile(file)
+              } catch (error) {
+                console.error('Failed to open file from event:', error)
+              }
             }
-            addFile(file)
           })
         } catch (error) {
           console.error('Failed to listen for open-file events:', error)

--- a/src/hooks/useFileOperations.ts
+++ b/src/hooks/useFileOperations.ts
@@ -40,6 +40,26 @@ export function useFileOperations() {
         } catch (error) {
           console.error('Failed to check for opened file:', error)
         }
+
+        // Listen for file-open events (macOS file associations)
+        try {
+          const { listen } = await import('@tauri-apps/api/event')
+          listen<{ path: string; name: string; content: string }>('open-file', (event) => {
+            const openedFile = event.payload
+            const file: MarkdownFile = {
+              id: nanoid(),
+              name: openedFile.name,
+              content: openedFile.content,
+              lastModified: Date.now(),
+              isDirty: false,
+              filePath: openedFile.path,
+              isUntitled: false,
+            }
+            addFile(file)
+          })
+        } catch (error) {
+          console.error('Failed to listen for open-file events:', error)
+        }
         return
       }
 

--- a/src/lib/markdown/mermaidExtension.ts
+++ b/src/lib/markdown/mermaidExtension.ts
@@ -69,6 +69,7 @@ export const MermaidNode = Node.create({
     return {
       setMermaid:
         (attributes?: { code?: string }) =>
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         ({ commands }: any) => {
           const code = attributes?.code || 'graph TD\n  A[Start] --> B[End]'
           return commands.insertContent({


### PR DESCRIPTION
`main` has no code signing, no notarization, and no auto-update path, so shipped builds are unsigned and users have no way to receive updates. This branch brings all three in.

- Sign and notarize macOS builds via Tauri's native notarization with a hardened runtime (`Entitlements.plist`)
- Drop the Intel macOS target; ship Apple Silicon only
- Add `tauri-plugin-updater` + `tauri-plugin-process`, configure the `latest.json` endpoint on GitHub releases, and check for updates on launch
- Update the release workflow to upload `.app.tar.gz` + `.sig` artifacts and generate `latest.json`
- Handle macOS file associations via Apple Events (`RunEvent::Opened`), gated to `cfg(target_os = "macos")`
- Fix triple-open race when launching by double-click — `PendingFiles` now buffers until the frontend marks ready, then emits directly; listener also dedupes by path (closes #6)
- Miscellaneous workflow fixes: correct DMG bundle path, delete existing release before recreating