### PR TITLE
fix: register macos file-association listener once

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,10 +1,14 @@
 import { useEffect, useCallback } from 'react'
+import { nanoid } from 'nanoid'
 import { AppLayout } from './components/layout/AppLayout'
 import { WelcomeScreen } from './components/welcome/WelcomeScreen'
 import { EditorView } from './components/editor/EditorView'
 import { useFileStore } from './store'
 import { useThemeStore } from './store'
+import { MarkdownFile } from './types'
 import { exportToPdf } from './lib/pdf/exporter'
+import * as db from './lib/db/fileStore'
+import { initDB } from './lib/db'
 import { isTauri } from './lib/storage/provider'
 
 function App() {
@@ -21,6 +25,84 @@ function App() {
       document.documentElement.classList.remove('dark')
     }
   }, [theme])
+
+  // Load persisted files (web) or the file the app was launched with (Tauri), and subscribe
+  // to macOS "Open With" events. Mounted exactly once at the App root so only a single
+  // listener is registered regardless of how many components consume useFileOperations.
+  useEffect(() => {
+    const { addFile, loadFile } = useFileStore.getState()
+
+    if (isTauri()) {
+      let unlisten: (() => void) | undefined
+      ;(async () => {
+        try {
+          const { invoke } = await import('@tauri-apps/api/core')
+          const openedFile = await invoke<{ path: string; name: string; content: string } | null>('get_opened_file')
+          if (openedFile) {
+            const file: MarkdownFile = {
+              id: nanoid(),
+              name: openedFile.name,
+              content: openedFile.content,
+              lastModified: Date.now(),
+              isDirty: false,
+              filePath: openedFile.path,
+              isUntitled: false,
+            }
+            addFile(file)
+          }
+        } catch (error) {
+          console.error('Failed to check for opened file:', error)
+        }
+
+        try {
+          const { listen } = await import('@tauri-apps/api/event')
+          const { invoke } = await import('@tauri-apps/api/core')
+          unlisten = await listen<string[]>('open-file', async (event) => {
+            for (const filePath of event.payload) {
+              const currentFiles = useFileStore.getState().files
+              const alreadyOpen = Array.from(currentFiles.values()).some(
+                (f) => f.filePath === filePath
+              )
+              if (alreadyOpen) continue
+
+              try {
+                const result = await invoke<{ path: string; name: string; content: string }>('read_file', { path: filePath })
+                const file: MarkdownFile = {
+                  id: nanoid(),
+                  name: result.name,
+                  content: result.content,
+                  lastModified: Date.now(),
+                  isDirty: false,
+                  filePath: result.path,
+                  isUntitled: false,
+                }
+                addFile(file)
+              } catch (error) {
+                console.error('Failed to open file from event:', error)
+              }
+            }
+          })
+        } catch (error) {
+          console.error('Failed to listen for open-file events:', error)
+        }
+      })()
+
+      return () => { unlisten?.() }
+    }
+
+    // Web: restore IndexedDB-backed files into the store without opening tabs.
+    ;(async () => {
+      try {
+        await initDB()
+        const savedFiles = await db.getAllFiles()
+        savedFiles.forEach((file) => {
+          loadFile({ ...file, isDirty: false })
+        })
+      } catch (error) {
+        console.error('Failed to load files from IndexedDB:', error)
+      }
+    })()
+  }, [])
 
   // Check for updates on launch (Tauri only)
   useEffect(() => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -34,7 +34,8 @@ function App() {
 
     if (isTauri()) {
       let unlisten: (() => void) | undefined
-      ;(async () => {
+
+      const initTauri = async () => {
         try {
           const { invoke } = await import('@tauri-apps/api/core')
           const openedFile = await invoke<{ path: string; name: string; content: string } | null>('get_opened_file')
@@ -85,13 +86,15 @@ function App() {
         } catch (error) {
           console.error('Failed to listen for open-file events:', error)
         }
-      })()
+      }
+
+      initTauri()
 
       return () => { unlisten?.() }
     }
 
     // Web: restore IndexedDB-backed files into the store without opening tabs.
-    ;(async () => {
+    const initWeb = async () => {
       try {
         await initDB()
         const savedFiles = await db.getAllFiles()
@@ -101,7 +104,9 @@ function App() {
       } catch (error) {
         console.error('Failed to load files from IndexedDB:', error)
       }
-    })()
+    }
+
+    initWeb()
   }, [])
 
   // Check for updates on launch (Tauri only)

--- a/src/hooks/useFileOperations.ts
+++ b/src/hooks/useFileOperations.ts
@@ -1,98 +1,19 @@
-import { useCallback, useEffect } from 'react'
+import { useCallback } from 'react'
 import { nanoid } from 'nanoid'
 import { saveAs as downloadFile } from 'file-saver'
 import { useFileStore } from '@/store'
 import { MarkdownFile } from '@/types'
 import * as db from '@/lib/db/fileStore'
-import { initDB } from '@/lib/db'
 import { getStorage, isTauri } from '@/lib/storage/provider'
 
 export function useFileOperations() {
   const {
     addFile,
-    loadFile,
     updateFile,
     removeFile,
     files,
     activeFileId,
   } = useFileStore()
-
-  // Initialize DB and load files on mount
-  useEffect(() => {
-    const loadFiles = async () => {
-      // In Tauri mode, check if app was opened with a file
-      if (isTauri()) {
-        try {
-          const { invoke } = await import('@tauri-apps/api/core')
-          const openedFile = await invoke<{ path: string; name: string; content: string } | null>('get_opened_file')
-          if (openedFile) {
-            const file: MarkdownFile = {
-              id: nanoid(),
-              name: openedFile.name,
-              content: openedFile.content,
-              lastModified: Date.now(),
-              isDirty: false,
-              filePath: openedFile.path,
-              isUntitled: false,
-            }
-            addFile(file)
-          }
-        } catch (error) {
-          console.error('Failed to check for opened file:', error)
-        }
-
-        // Listen for file-open events (macOS file associations while app is already running)
-        try {
-          const { listen } = await import('@tauri-apps/api/event')
-          const { invoke } = await import('@tauri-apps/api/core')
-          listen<string[]>('open-file', async (event) => {
-            for (const filePath of event.payload) {
-              // Skip if this file is already open
-              const currentFiles = useFileStore.getState().files
-              const alreadyOpen = Array.from(currentFiles.values()).some(
-                (f) => f.filePath === filePath
-              )
-              if (alreadyOpen) continue
-
-              try {
-                const result = await invoke<{ path: string; name: string; content: string }>('read_file', { path: filePath })
-                const file: MarkdownFile = {
-                  id: nanoid(),
-                  name: result.name,
-                  content: result.content,
-                  lastModified: Date.now(),
-                  isDirty: false,
-                  filePath: result.path,
-                  isUntitled: false,
-                }
-                addFile(file)
-              } catch (error) {
-                console.error('Failed to open file from event:', error)
-              }
-            }
-          })
-        } catch (error) {
-          console.error('Failed to listen for open-file events:', error)
-        }
-        return
-      }
-
-      // Web mode: load from IndexedDB
-      try {
-        await initDB()
-        const savedFiles = await db.getAllFiles()
-
-        // Load all saved files into the store WITHOUT opening them in tabs
-        savedFiles.forEach((file) => {
-          loadFile({ ...file, isDirty: false })
-        })
-      } catch (error) {
-        console.error('Failed to load files from IndexedDB:', error)
-      }
-    }
-
-    loadFiles()
-  }, []) // Empty deps - only run on mount
 
   const createNewFile = useCallback(
     async (name: string, content: string = '') => {


### PR DESCRIPTION
The post-merge v1.0.0-rc9 release still opens three tabs when a file is sent to an already-running app via Finder's Open With.

Root cause: `useFileOperations` is consumed by EditorView, TabBar, and WelcomeScreen. The hook's init `useEffect` ran per caller, so three `listen('open-file', …)` subscriptions stacked up. One Apple Event → three listeners → three `addFile` calls.

Moving the init (`get_opened_file`, the `open-file` listener, and the web-mode IndexedDB restore) to App.tsx fixes it — mounted exactly once, with a cleanup to unlisten on unmount.