### PR TITLE
chore: bump version to 1.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "markitdown-editor",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "markitdown-editor",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "dependencies": {
         "@codemirror/lang-markdown": "^6.5.0",
         "@radix-ui/react-dialog": "^1.1.15",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "markitdown-editor",
   "private": true,
-  "version": "1.0.0",
+  "version": "1.0.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1833,7 +1833,7 @@ checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
 
 [[package]]
 name = "markdown-editor"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "log",
  "serde",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "markdown-editor"
-version = "1.0.0"
+version = "1.0.1"
 description = "A beautiful markdown WYSIWYG editor"
 authors = ["DonkeyWork"]
 license = "MIT"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Markdown Editor",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "identifier": "com.donkeywork.markdowneditor",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
Release tags up to v1.0.0-rc10 embedded version `1.0.0` in the binary (package.json, Cargo.toml, tauri.conf.json), but the tag-derived version in `latest.json` was `1.0.0-rcN`. Semver puts pre-releases below the release, so the updater always concluded "no upgrade available" and in-app auto-update never fired.

Bumping the embedded version to 1.0.1. Future releases tag `v1.0.1`, `v1.0.2`, etc. — no more rc pre-release suffixes — and the updater compares versions correctly.

Already-installed copies (all at `1.0.0`) will pick up `1.0.1` on their next launch once it's tagged.