### PR TITLE
feat: unify export menu and bump to 1.0.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "markitdown-editor",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "markitdown-editor",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "dependencies": {
         "@codemirror/lang-markdown": "^6.5.0",
         "@radix-ui/react-dialog": "^1.1.15",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "markitdown-editor",
   "private": true,
-  "version": "1.0.1",
+  "version": "1.0.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1835,6 +1835,7 @@ checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
 name = "markdown-editor"
 version = "1.0.1"
 dependencies = [
+ "base64 0.22.1",
  "log",
  "serde",
  "serde_json",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1833,7 +1833,7 @@ checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
 
 [[package]]
 name = "markdown-editor"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "base64 0.22.1",
  "log",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "markdown-editor"
-version = "1.0.1"
+version = "1.0.2"
 description = "A beautiful markdown WYSIWYG editor"
 authors = ["DonkeyWork"]
 license = "MIT"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -21,6 +21,7 @@ tauri-build = { version = "2.5.3", features = [] }
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 log = "0.4"
+base64 = "0.22"
 tauri = { version = "2.9.5", features = [] }
 tauri-plugin-log = "2"
 tauri-plugin-dialog = "2"

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -7,6 +7,7 @@
   ],
   "permissions": [
     "core:default",
+    "core:webview:allow-print",
     "dialog:default",
     "fs:default",
     "updater:default",

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,3 +1,4 @@
+use base64::{engine::general_purpose::STANDARD as BASE64, Engine};
 use serde::{Deserialize, Serialize};
 use std::fs;
 use std::path::PathBuf;
@@ -75,6 +76,28 @@ async fn save_file_dialog(
     }
 }
 
+/// Save file dialog for PDF exports - returns the chosen path
+#[tauri::command]
+async fn save_pdf_dialog(
+    app: tauri::AppHandle,
+    default_name: String,
+) -> Result<Option<String>, String> {
+    let file_path = app
+        .dialog()
+        .file()
+        .add_filter("PDF", &["pdf"])
+        .set_file_name(&default_name)
+        .blocking_save_file();
+
+    match file_path {
+        Some(path) => {
+            let path_buf = path.into_path().map_err(|e| e.to_string())?;
+            Ok(Some(path_buf.to_string_lossy().to_string()))
+        }
+        None => Ok(None),
+    }
+}
+
 /// Read a file from disk
 #[tauri::command]
 async fn read_file(path: String) -> Result<FileResult, String> {
@@ -97,6 +120,16 @@ async fn read_file(path: String) -> Result<FileResult, String> {
 #[tauri::command]
 async fn write_file(path: String, content: String) -> Result<(), String> {
     fs::write(&path, &content).map_err(|e| e.to_string())
+}
+
+/// Write raw bytes to a file on disk (used for binary exports like PDF).
+/// Content is base64-encoded because Tauri v2's JSON IPC serializes byte arrays
+/// as number-per-token JSON, which is O(10x) overhead and blocks the UI thread
+/// for multi-megabyte payloads.
+#[tauri::command]
+async fn write_binary_file(path: String, content_base64: String) -> Result<(), String> {
+    let bytes = BASE64.decode(content_base64.as_bytes()).map_err(|e| e.to_string())?;
+    fs::write(&path, &bytes).map_err(|e| e.to_string())
 }
 
 /// Get the path to the recent files JSON
@@ -267,8 +300,10 @@ pub fn run() {
         .invoke_handler(tauri::generate_handler![
             open_file_dialog,
             save_file_dialog,
+            save_pdf_dialog,
             read_file,
             write_file,
+            write_binary_file,
             get_opened_file,
             get_recent_files,
             add_recent_file,

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Markdown Editor",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "identifier": "com.donkeywork.markdowneditor",
   "build": {
     "frontendDist": "../dist",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -135,14 +135,29 @@ function App() {
     checkForUpdates()
   }, [])
 
-  const handleDownloadMarkdown = useCallback(() => {
+  const handleExportMarkdown = useCallback(async () => {
     if (!activeFile) return
+
+    const defaultName = activeFile.name.endsWith('.md') ? activeFile.name : `${activeFile.name}.md`
+
+    if (isTauri()) {
+      try {
+        const { invoke } = await import('@tauri-apps/api/core')
+        const path = await invoke<string | null>('save_file_dialog', { defaultName })
+        if (!path) return
+        await invoke('write_file', { path, content: activeFile.content })
+      } catch (error) {
+        console.error('Failed to export markdown:', error)
+        alert('Failed to export markdown. Please try again.')
+      }
+      return
+    }
 
     const blob = new Blob([activeFile.content], { type: 'text/markdown' })
     const url = URL.createObjectURL(blob)
     const a = document.createElement('a')
     a.href = url
-    a.download = activeFile.name.endsWith('.md') ? activeFile.name : `${activeFile.name}.md`
+    a.download = defaultName
     document.body.appendChild(a)
     a.click()
     document.body.removeChild(a)
@@ -152,16 +167,39 @@ function App() {
   const handleExportPdf = useCallback(async () => {
     if (!activeFile) return
 
+    const defaultName = activeFile.name.endsWith('.md')
+      ? activeFile.name.replace('.md', '.pdf')
+      : `${activeFile.name}.pdf`
+
     try {
-      const filename = activeFile.name.endsWith('.md')
-        ? activeFile.name.replace('.md', '.pdf')
-        : `${activeFile.name}.pdf`
+      if (isTauri()) {
+        // Clone the live preview DOM into a body-level container that the print
+        // stylesheet promotes as the sole visible element. WebKit then runs its
+        // native print pipeline on that container — fast, vector-quality, and
+        // honors CSS page-break rules.
+        const preview = document.querySelector<HTMLElement>('.ProseMirror')
+        if (!preview) {
+          alert('No preview content to export.')
+          return
+        }
+        const printRoot = document.createElement('div')
+        printRoot.id = 'print-root'
+        printRoot.innerHTML = preview.innerHTML
+        document.body.appendChild(printRoot)
+        try {
+          window.print()
+        } finally {
+          document.body.removeChild(printRoot)
+        }
+        return
+      }
 
       await exportToPdf({
         markdown: activeFile.content,
-        filename,
+        filename: defaultName,
       })
     } catch (error) {
+      console.error('Failed to export PDF:', error)
       alert('Failed to export PDF. Please try again.')
     }
   }, [activeFile])
@@ -170,7 +208,7 @@ function App() {
     <AppLayout showTabs={hasOpenFiles}>
       {hasOpenFiles ? (
         <EditorView
-          onDownloadMarkdown={handleDownloadMarkdown}
+          onExportMarkdown={handleExportMarkdown}
           onExportPdf={handleExportPdf}
         />
       ) : (

--- a/src/components/editor/EditorView.tsx
+++ b/src/components/editor/EditorView.tsx
@@ -18,12 +18,39 @@ import {
 } from '@/components/ui/dropdown-menu'
 import { DEFAULT_FILE_CONTENT } from '@/lib/constants'
 
-interface EditorViewProps {
-  onDownloadMarkdown: () => void
+interface ExportMenuProps {
+  isDesktop: boolean
+  onExportMarkdown: () => void
   onExportPdf: () => void
 }
 
-export function EditorView({ onDownloadMarkdown, onExportPdf }: EditorViewProps) {
+function ExportMenu({ isDesktop, onExportMarkdown, onExportPdf }: ExportMenuProps) {
+  const Icon = isDesktop ? FileOutput : Download
+  const label = isDesktop ? 'Export' : 'Download'
+  const markdownLabel = isDesktop ? 'Export as Markdown' : 'Download as Markdown'
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button variant="ghost" size="sm" className="h-7 px-3 text-xs">
+          <Icon className="h-3.5 w-3.5 mr-1.5" />
+          {label}
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        <DropdownMenuItem onClick={onExportMarkdown}>{markdownLabel}</DropdownMenuItem>
+        <DropdownMenuItem onClick={onExportPdf}>Export as PDF</DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}
+
+interface EditorViewProps {
+  onExportMarkdown: () => void
+  onExportPdf: () => void
+}
+
+export function EditorView({ onExportMarkdown, onExportPdf }: EditorViewProps) {
   const activeFile = useFileStore((state) => state.getActiveFile())
   const { saveFileContent, createNewFile, openFile } = useFileOperations()
   const [viewMode, setViewMode] = useState<ViewMode>('split')
@@ -121,29 +148,11 @@ export function EditorView({ onDownloadMarkdown, onExportPdf }: EditorViewProps)
           {viewMode !== 'split' && (
             <div className="flex items-center gap-2">
               <ViewModeToggle viewMode={viewMode} onViewModeChange={setViewMode} />
-              {isDesktop ? (
-                <Button variant="ghost" size="sm" className="h-7 px-3 text-xs" onClick={onExportPdf}>
-                  <FileOutput className="h-3.5 w-3.5 mr-1.5" />
-                  Export PDF
-                </Button>
-              ) : (
-                <DropdownMenu>
-                  <DropdownMenuTrigger asChild>
-                    <Button variant="ghost" size="sm" className="h-7 px-3 text-xs">
-                      <Download className="h-3.5 w-3.5 mr-1.5" />
-                      Download
-                    </Button>
-                  </DropdownMenuTrigger>
-                  <DropdownMenuContent align="end">
-                    <DropdownMenuItem onClick={onDownloadMarkdown}>
-                      Download as Markdown
-                    </DropdownMenuItem>
-                    <DropdownMenuItem onClick={onExportPdf}>
-                      Export as PDF
-                    </DropdownMenuItem>
-                  </DropdownMenuContent>
-                </DropdownMenu>
-              )}
+              <ExportMenu
+                isDesktop={isDesktop}
+                onExportMarkdown={onExportMarkdown}
+                onExportPdf={onExportPdf}
+              />
             </div>
           )}
         </div>
@@ -178,29 +187,11 @@ export function EditorView({ onDownloadMarkdown, onExportPdf }: EditorViewProps)
           {viewMode !== 'split' && (
             <div className="flex items-center gap-2">
               <ViewModeToggle viewMode={viewMode} onViewModeChange={setViewMode} />
-              {isDesktop ? (
-                <Button variant="ghost" size="sm" className="h-7 px-3 text-xs" onClick={onExportPdf}>
-                  <FileOutput className="h-3.5 w-3.5 mr-1.5" />
-                  Export PDF
-                </Button>
-              ) : (
-                <DropdownMenu>
-                  <DropdownMenuTrigger asChild>
-                    <Button variant="ghost" size="sm" className="h-7 px-3 text-xs">
-                      <Download className="h-3.5 w-3.5 mr-1.5" />
-                      Download
-                    </Button>
-                  </DropdownMenuTrigger>
-                  <DropdownMenuContent align="end">
-                    <DropdownMenuItem onClick={onDownloadMarkdown}>
-                      Download as Markdown
-                    </DropdownMenuItem>
-                    <DropdownMenuItem onClick={onExportPdf}>
-                      Export as PDF
-                    </DropdownMenuItem>
-                  </DropdownMenuContent>
-                </DropdownMenu>
-              )}
+              <ExportMenu
+                isDesktop={isDesktop}
+                onExportMarkdown={onExportMarkdown}
+                onExportPdf={onExportPdf}
+              />
             </div>
           )}
         </div>
@@ -269,22 +260,11 @@ export function EditorView({ onDownloadMarkdown, onExportPdf }: EditorViewProps)
               <h3 className="text-sm font-medium">Preview</h3>
               <div className="flex items-center gap-2">
                 <ViewModeToggle viewMode={viewMode} onViewModeChange={setViewMode} />
-                <DropdownMenu>
-                  <DropdownMenuTrigger asChild>
-                    <Button variant="ghost" size="sm" className="h-7 px-3 text-xs">
-                      <Download className="h-3.5 w-3.5 mr-1.5" />
-                      Download
-                    </Button>
-                  </DropdownMenuTrigger>
-                  <DropdownMenuContent align="end">
-                    <DropdownMenuItem onClick={onDownloadMarkdown}>
-                      Download as Markdown
-                    </DropdownMenuItem>
-                    <DropdownMenuItem onClick={onExportPdf}>
-                      Export as PDF
-                    </DropdownMenuItem>
-                  </DropdownMenuContent>
-                </DropdownMenu>
+                <ExportMenu
+                  isDesktop={isDesktop}
+                  onExportMarkdown={onExportMarkdown}
+                  onExportPdf={onExportPdf}
+                />
               </div>
             </div>
             <div className="flex-1 flex flex-col overflow-hidden">

--- a/src/index.css
+++ b/src/index.css
@@ -150,3 +150,82 @@
     display: none;
   }
 }
+
+/* Print-only container that we clone the preview HTML into right before window.print().
+   Hidden on screen; promoted to the only visible element when the OS print pipeline runs. */
+#print-root {
+  display: none;
+}
+
+@media print {
+  @page {
+    margin: 18mm;
+  }
+
+  body > *:not(#print-root) {
+    display: none !important;
+  }
+
+  #print-root {
+    display: block !important;
+    color: #000 !important;
+    background: #fff !important;
+    font-family: system-ui, -apple-system, sans-serif;
+    font-size: 11pt;
+    line-height: 1.55;
+  }
+
+  #print-root *,
+  #print-root *::before,
+  #print-root *::after {
+    color: #000 !important;
+    background: transparent !important;
+    box-shadow: none !important;
+  }
+
+  #print-root pre {
+    background: #f4f4f4 !important;
+    border: 1px solid #ddd;
+    padding: 8px;
+    white-space: pre-wrap;
+    word-wrap: break-word;
+  }
+
+  #print-root code {
+    font-family: ui-monospace, SFMono-Regular, monospace;
+    font-size: 0.9em;
+  }
+
+  #print-root img,
+  #print-root svg {
+    max-width: 100% !important;
+    height: auto !important;
+  }
+
+  /* Hide interactive chrome embedded in the preview (copy buttons, mermaid toolbars, etc.) */
+  #print-root button,
+  #print-root [contenteditable]::after,
+  #print-root .ProseMirror-widget {
+    display: none !important;
+  }
+
+  /* Keep block-level content from splitting across pages. */
+  #print-root pre,
+  #print-root table,
+  #print-root img,
+  #print-root svg,
+  #print-root figure,
+  #print-root blockquote,
+  #print-root .mermaid-diagram,
+  #print-root .mermaid-diagram-pdf {
+    break-inside: avoid;
+    page-break-inside: avoid;
+  }
+  #print-root h1,
+  #print-root h2,
+  #print-root h3,
+  #print-root h4 {
+    break-after: avoid;
+    page-break-after: avoid;
+  }
+}

--- a/src/lib/pdf/exporter.ts
+++ b/src/lib/pdf/exporter.ts
@@ -9,7 +9,12 @@ export interface ExportPdfOptions {
   markdown: string
 }
 
-export async function exportToPdf({ filename = 'document.pdf', markdown }: ExportPdfOptions): Promise<void> {
+export interface RenderPdfOptions {
+  markdown: string
+  scale?: number
+}
+
+async function buildPdf({ markdown, scale = 2 }: RenderPdfOptions): Promise<jsPDF> {
   // Initialize mermaid with light theme
   mermaid.initialize({
     startOnLoad: false,
@@ -88,7 +93,7 @@ export async function exportToPdf({ filename = 'document.pdf', markdown }: Expor
 
     // Capture the content as canvas
     const canvas = await html2canvas(container, {
-      scale: 2, // Higher quality
+      scale,
       useCORS: true,
       logging: false,
       backgroundColor: '#ffffff',
@@ -117,10 +122,19 @@ export async function exportToPdf({ filename = 'document.pdf', markdown }: Expor
       heightLeft -= pageHeight
     }
 
-    // Download the PDF
-    pdf.save(filename)
+    return pdf
   } finally {
     // Clean up
     document.body.removeChild(container)
   }
+}
+
+export async function exportToPdf({ filename = 'document.pdf', markdown }: ExportPdfOptions): Promise<void> {
+  const pdf = await buildPdf({ markdown })
+  pdf.save(filename)
+}
+
+export async function renderPdfBytes(options: RenderPdfOptions): Promise<Uint8Array> {
+  const pdf = await buildPdf(options)
+  return new Uint8Array(pdf.output('arraybuffer'))
 }


### PR DESCRIPTION
The desktop and web flows had diverged: desktop showed an "Export PDF" button while web showed a "Download" dropdown, and the dropdown JSX was duplicated three times across the editor view. Unify them and route desktop saves through the native dialog so the auto-updater has a meaningful 1.0.1 → 1.0.2 transition to ship.

- Replace the three inline dropdowns with a single `ExportMenu` component; label it "Export" on desktop, keep "Download" on web for familiarity
- Markdown export on desktop now calls `save_file_dialog` + `write_file` instead of triggering a browser download
- PDF export on desktop renders via the WebKit print pipeline by cloning the live preview into a body-level `#print-root` and calling `window.print()`, giving vector-quality output that respects CSS page-break rules; web flow keeps the html2canvas/jsPDF path
- Add `save_pdf_dialog` and `write_binary_file` Rust commands (base64-encoded over IPC to avoid Tauri's per-byte JSON serialization overhead) and grant `core:webview:allow-print`
- Bump every embedded version to 1.0.2 (`package.json`, `package-lock.json`, `src-tauri/Cargo.toml`, `src-tauri/Cargo.lock`, `src-tauri/tauri.conf.json`) so the updater on installed 1.0.1 builds picks up the next tag